### PR TITLE
manage groups on regex

### DIFF
--- a/memorpy/MemWorker.py
+++ b/memorpy/MemWorker.py
@@ -95,14 +95,14 @@ class MemWorker(object):
         ftype = ftype.lower().strip()
         if type(value) is list:
             ftype = 'group'
-        if ftype == 're':
+        if ftype == 're' or ftype == 'groups':
             if type(value) is str:
                 regex = re.compile(value)
             else:
                 regex = value
         if ftype == 'float':
             structtype, structlen = utils.type_unpack(ftype)
-        elif ftype != 'match' and ftype != 'group' and ftype != 're':
+        elif ftype != 'match' and ftype != 'group' and ftype != 're' and ftype != 'groups':
             structtype, structlen = utils.type_unpack(ftype)
             value = struct.pack(structtype, value)
         for offset, chunk in self.process.iter_region(start_offset=start_offset, end_offset=end_offset, protec=protec):
@@ -157,6 +157,10 @@ class MemWorker(object):
                                 yield self.Address(soffset, 'float')
                         except Exception as e:
                             pass
+
+                elif ftype == 'groups':
+                    for res in regex.findall(b):
+                        yield res
 
                 else:
                     index = b.find(value)


### PR DESCRIPTION
I have changed all regex to manage groups. For example, now regex are like that ("Login" and "Password" are 2 different groups): 
`("Gmail","&Email=(?P<Login>.{1,99})?&Passwd=(?P<Password>.{1,99})?&PersistentCookie="),`


Here is the main (used for text):
```
for service, regex in mimikittenz_regex:
            for x in mw.mem_search(regex, ftype='groups'):
                print x
```
It returns only the tuple containing the login and password found and not the unecessary request. I have tested it on Linux and Windows and works great.