### PR TITLE
Removing some dependencies (win32api, win32security, etc) using ctypes

### DIFF
--- a/memorpy/WinStructures.py
+++ b/memorpy/WinStructures.py
@@ -23,6 +23,16 @@ else:
     ULONG_PTR = c_ulong
 
 
+class SECURITY_DESCRIPTOR(Structure): 
+    _fields_ = [
+        ('SID', DWORD),
+        ('group', DWORD),
+        ('dacl', DWORD),
+        ('sacl', DWORD),
+        ('test', DWORD)
+    ]
+PSECURITY_DESCRIPTOR = POINTER(SECURITY_DESCRIPTOR)
+
 class MEMORY_BASIC_INFORMATION(Structure):
     _fields_ = [('BaseAddress', c_void_p),
      ('AllocationBase', c_void_p),
@@ -176,3 +186,5 @@ MEM_COMMIT = 4096
 MEM_FREE = 65536
 MEM_RESERVE = 8192
 
+UNPROTECTED_DACL_SECURITY_INFORMATION = 536870912
+DACL_SECURITY_INFORMATION = 4

--- a/memorpy/wintools.py
+++ b/memorpy/wintools.py
@@ -14,9 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with memorpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import win32gui
-import win32con
-import win32console
+from ctypes import windll
 import time
 
 def start_winforeground_daemon():
@@ -24,11 +22,14 @@ def start_winforeground_daemon():
 	t=threading.Thread(target=window_foreground_loop)
 	t.daemon=True
 	t.start()
-	
+
 def window_foreground_loop(timeout=20):
 	""" set the windows python console to the foreground (for example when you are working with a fullscreen program) """
-	hwnd=int(win32console.GetConsoleWindow())
+	hwnd = windll.kernel32.GetConsoleWindow()
+	HWND_TOPMOST 	= -1 
+	SWP_NOMOVE 		= 2
+	SWP_NOSIZE 		= 1
 	while True:
-		win32gui.SetWindowPos(hwnd, win32con.HWND_TOPMOST, 0,0,0,0, win32con.SWP_NOMOVE | win32con.SWP_NOSIZE)
+		windll.user32.SetWindowPos(hwnd, HWND_TOPMOST, 0,0,0,0, SWP_NOMOVE | SWP_NOSIZE)
 		time.sleep(timeout)
 	


### PR DESCRIPTION
I have removed all win32xxx dependencies on lazagne but I use memorpy as dependency as well (and it used these dependencies too). So I have removed from memorpy all win32xxx import using ctypes. 

Sometimes, when my VM becomes slow, doing a memory scan could be extremely slow (more than 160s to scan 2 processes newly created). So I decided to scan only child process to gain time, I added it on [lazagne](https://github.com/AlessandroZ/LaZagne/blob/master/Windows/lazagne/softwares/memory/memorydump.py#L73) but not on your mimkittenz example (I wanted to let you know). 

I have a question which has nothing to do with memorpy. Mimikittenz regex are limited to some services (Gmail, Facebook, etc.). So at first I wanted to do a generic regex to match all password field and to retrieve [everything](https://github.com/AlessandroZ/LaZagne/blob/master/Windows/lazagne/softwares/memory/memorydump.py#L21) but doing so, I don't have the relation between the associated URL. So, what's best for you, grepping only well known services or retrieving every credentials (login / password) without the associated URL ? I'm sounding people trying to know what's the best lol. 

If you have time to import memorpy as a pip package, it could be great. ;)